### PR TITLE
Make syntax table comment entries more specific

### DIFF
--- a/cook-mode.el
+++ b/cook-mode.el
@@ -39,9 +39,9 @@
 (defvar cook-mode-syntax-table nil "Syntax table used while in `cook-mode'.")
 (setq cook-mode-syntax-table
   (let ((st (make-syntax-table)))
-     (modify-syntax-entry ?\[ ". 124b" st)
-     (modify-syntax-entry ?\] ". 124b" st)
-     (modify-syntax-entry ?- ". 1b23" st)
+     (modify-syntax-entry ?\[ ". 1b" st)
+     (modify-syntax-entry ?\] ". 4b" st)
+     (modify-syntax-entry ?- ". 123b" st)
      (modify-syntax-entry ?\n "> b" st)
     st))
 


### PR DESCRIPTION
Thanks for creating cook-mode, I love it!

I noticed that the specifications for comment syntax highlighting is a bit loose. This PR tightens it up a bit. 

For example, the character sequences `[[` and `]]` will start comments: 

![Screen Shot 2022-04-18 at 10 41 20 AM](https://user-images.githubusercontent.com/136000/163851077-d8003ab2-7f3e-40c3-a142-1a88826f56a2.png)

Tightening up the spec a bit reduces the incorrect highlighting: 

![Screen Shot 2022-04-18 at 10 41 31 AM](https://user-images.githubusercontent.com/136000/163851213-cf9c2794-b759-4146-91d3-6e3996337536.png)

However, multiline block comments still don't work =(. I'm not sure there is a good way to support multi-line block comments with emacs' syntax table facilities. 


