### PR TITLE
Add show-ingredients command

### DIFF
--- a/cook-mode.el
+++ b/cook-mode.el
@@ -164,6 +164,37 @@ of the form (INGREDIENT QUANTITY UNITS), where UNITS can be nil."
         (add-to-list 'ingredients (match-string-no-properties 0) t)))
     ingredients))
 
+(defun cook-parse-ingredient (str)
+  "Parse an ingredient string into (INGREDIENT QUANTITY UNITS)
+Example: \"@olive oil{2%tbsp}\" => (\"olive oil\" 2 \"tbsp\")"
+  nil
+  )
+
+
+(defun cook-match () ""
+       (interactive)
+       (re-search-forward cook-ingredient-re (point-max) t))
+
+(defun cook-show-ingredients ()
+  "Show ingredients list"
+  (interactive)
+  ;; Gather ingredients into a list => (("eggs" 5) ("sugar" 20 "mg"))
+  ;; Format ingredients
+  ;; Display
+    (message "hello!\n\nworld!"))
+
+; This would be a cool function
+;(defun cook-insert-ingredients-list ())
+
+;;; Keymap ====================================================================
+
+(defvar cook-mode-map
+  (let ((map (make-keymap)))
+    (define-key map (kbd "C-c i") 'cook-show-ingredients)
+    map)
+  "Keymap for Cook major mode.")
+
+
 ;;;###autoload
 (define-derived-mode cook-mode text-mode "cook"
   "A mode for cooklang recipes"

--- a/cook-mode.el
+++ b/cook-mode.el
@@ -153,6 +153,17 @@ Group 3: Matches the quantity if available.
   '((t :inherit font-lock-string-face))
   "Face for timer")
 
+
+(defun cook-ingredients-list ()
+  "Return the ingredients list for the current buffer. Each element is
+of the form (INGREDIENT QUANTITY UNITS), where UNITS can be nil."
+  (let ((ingredients '()))
+    (save-excursion
+      (while (and (< (point) (point-max))
+                  (re-search-forward cook-ingredient-re (point-max) t))
+        (add-to-list 'ingredients (match-string-no-properties 0) t)))
+    ingredients))
+
 ;;;###autoload
 (define-derived-mode cook-mode text-mode "cook"
   "A mode for cooklang recipes"

--- a/cook-mode.el
+++ b/cook-mode.el
@@ -45,9 +45,23 @@
      (modify-syntax-entry ?\n "> b" st)
     st))
 
+;;; Regular Expressions ========================================================
+
+;; Ingredient extraction
+(defconst cook-ingredient-re
+  "\\(?1:@\\)\\(?:\\(?2:[A-z\s-]*\\){\\(?3:[^}]*\\)}\\|\\(?2:[A-z]*\\)\\)"
+  "Regular expression for matching an ingredient.
+
+Group 1: Matches @ marker.
+Group 2: Matches the ingredient.
+Group 3: Matches the quantity if available.
+")
+
+;;; Syntax Highlighting ========================================================
+
 (defvar cook-mode-font-lock nil "Font lock for `cook-mode'.")
 
-(setq cook-mode-font-lock'(
+(setq cook-mode-font-lock `(
     ;; source | author
     ("\\(>>\\) \\(source\\|author\\)\\(:\\)\\(.*$\\)" 1 'font-lock-comment-face)
     ("\\(>>\\) \\(source\\|author\\)\\(:\\)\\(.*$\\)" 3 'font-lock-comment-face)
@@ -79,9 +93,9 @@
     ("\\(?1:#\\)\\(?:\\(?2:[A-z\s-]*\\){\\(?3:[^}]*\\)}\\|\\(?2:[A-z]*\\)\\)" 2 'cook-cookware-face)
     ("\\(?1:#\\)\\(?:\\(?:[A-z\s-]*\\){\\(?3:[^}]*\\)}\\|\\(?:[A-z]*\\)\\)" 3 'cook-cookware-quantity-face)
 
-    ("\\(?1:@\\)\\(?:\\(?2:[A-z\s-]*\\){\\(?3:[^}]*\\)}\\|\\(?2:[A-z]*\\)\\)" 1 'cook-ingredient-char-face)
-    ("\\(?1:@\\)\\(?:\\(?2:[A-z\s-]*\\){\\(?3:[^}]*\\)}\\|\\(?2:[A-z]*\\)\\)" 2 'cook-ingredient-face)
-    ("\\(?:@\\)\\(?:\\(?:[A-z\s-]*\\){\\(?3:[^}]*\\)}\\|\\(:[A-z]*\\)\\)" 3 'cook-ingredient-quantity-face)
+    (,cook-ingredient-re 1 'cook-ingredient-char-face)
+    (,cook-ingredient-re 2 'cook-ingredient-face)
+    (,cook-ingredient-re 3 'cook-ingredient-quantity-face)
     ))
 
 (defface cook-source-author-keyword-face

--- a/cook-mode.el
+++ b/cook-mode.el
@@ -165,11 +165,10 @@ Example: \"@olive oil{2%tbsp}\" => (\"olive oil\" 2 \"tbsp\")"
          (quantity-str (substring ingredient-str (nth 6 m) (nth 7 m))))
     (if (seq-contains-p quantity-str ?%)
         (let* ((q-split (split-string quantity-str "%"))
-               ; TODO - need to parse fractions.
-               (quantity (string-to-number (first q-split)))
+               (quantity (first q-split))
                (units (second q-split)))
           (list ingredient quantity units))
-      (list ingredient (string-to-number quantity-str) nil))))
+      (list ingredient quantity-str nil))))
 
 (defun cook-ingredients-list ()
   "Return the ingredients list for the current buffer. Each element is
@@ -195,12 +194,6 @@ of the form (INGREDIENT QUANTITY UNITS), where UNITS can be nil."
                              (format "%s\t%s\n" (first i) (second i))))
                            ingredients))))
     (message ingredients-table)))
-
-  ;; Format ingredients
-  ;; Display
-
-; This would be a cool function
-;(defun cook-insert-ingredients-list ())
 
 ;;; Keymap ====================================================================
 


### PR DESCRIPTION
Thought it would be cool to extend `cook-mode` to have some of the functionality from the CLI. 

This PR adds `cook-show-ingredients` as an interactive command for extracting out an ingredients list. Right now it just prints into the echo area: 

![Screen Shot 2022-05-09 at 4 27 15 PM](https://user-images.githubusercontent.com/136000/167514638-15dc3580-c8df-4d8d-8b8a-96cdf73470a6.png)

I've also added a custom keymap for cook-mode so that I could bind the new command to `C-c i`. Also, I pulled out one of regexes from the font-lock to re-use it in the ingredient parsing.  

Let me know if there is any way I could improve the PR. 