### PR TITLE
Use `[:alpha:]` instead of `[A-z]` for regexes

### DIFF
--- a/cook-mode.el
+++ b/cook-mode.el
@@ -49,7 +49,7 @@
 
 ;; Ingredient extraction
 (defconst cook-ingredient-re
-  "\\(?1:@\\)\\(?:\\(?2:[A-z\s-]*\\){\\(?3:[^}]*\\)}\\|\\(?2:[A-z]*\\)\\)"
+  "\\(?1:@\\)\\(?:\\(?2:[[:alpha:]\s-]*\\){\\(?3:[^}]*\\)}\\|\\(?2:[:alpha:]*\\)\\)"
   "Regular expression for matching an ingredient.
 
 Group 1: Matches @ marker.
@@ -89,9 +89,9 @@ Group 3: Matches the quantity if available.
     ("\\(?1:~\\){\\(?2:[^}]*\\)}" 1 'cook-timer-char-face)
     ("\\(?1:~\\){\\(?2:[^}]*\\)}" 2 'cook-timer-face)
 
-    ("\\(?1:#\\)\\(?:\\(?2:[A-z\s-]*\\){\\(?3:[^}]*\\)}\\|\\(?2:[A-z]*\\)\\)" 1 'cook-cookware-char-face)
-    ("\\(?1:#\\)\\(?:\\(?2:[A-z\s-]*\\){\\(?3:[^}]*\\)}\\|\\(?2:[A-z]*\\)\\)" 2 'cook-cookware-face)
-    ("\\(?1:#\\)\\(?:\\(?:[A-z\s-]*\\){\\(?3:[^}]*\\)}\\|\\(?:[A-z]*\\)\\)" 3 'cook-cookware-quantity-face)
+    ("\\(?1:#\\)\\(?:\\(?2:[[:alpha:]\s-]*\\){\\(?3:[^}]*\\)}\\|\\(?2:[:alpha:]*\\)\\)" 1 'cook-cookware-char-face)
+    ("\\(?1:#\\)\\(?:\\(?2:[[:alpha:]\s-]*\\){\\(?3:[^}]*\\)}\\|\\(?2:[:alpha:]*\\)\\)" 2 'cook-cookware-face)
+    ("\\(?1:#\\)\\(?:\\(?:[[:alpha:]\s-]*\\){\\(?3:[^}]*\\)}\\|\\(?:[:alpha:]*\\)\\)" 3 'cook-cookware-quantity-face)
 
     (,cook-ingredient-re 1 'cook-ingredient-char-face)
     (,cook-ingredient-re 2 'cook-ingredient-face)


### PR DESCRIPTION
I've been testing this with recipes in Spanish and was getting wrong highlights:
![image](https://github.com/cooklang/cook-mode/assets/3924815/7e19096f-b41c-42d7-b919-51c50a685ed8)
![image](https://github.com/cooklang/cook-mode/assets/3924815/4f805075-fdc8-459a-ac89-c461acda32de)

I pinpointed the issue to the regexes, which are using `[A-z]`, and thus not matching letters with accents. I've changed them to use the [character class `[:alpha:]`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Char-Classes.html#Char-Classes), and the problem goes away.
![image](https://github.com/cooklang/cook-mode/assets/3924815/56ecfd6a-02d7-43fc-99b2-b6da0665ecd6)
![image](https://github.com/cooklang/cook-mode/assets/3924815/8ff73f3e-273c-4f7c-bc3c-8a4bf99ea2e0)

Thank you!