### PR TITLE
Fix `course` syntax highlighting

### DIFF
--- a/cook-mode.el
+++ b/cook-mode.el
@@ -121,6 +121,14 @@ Group 3: Matches the quantity if available.
   '((t :inherit font-lock-string-face))
   "Face for time required")
 
+(defface cook-course-keyword-face
+  '((t :inherit font-lock-keyword-face))
+  "Face for course keyword")
+
+(defface cook-course-face
+  '((t :inherit font-lock-string-face))
+  "Face for course")
+
 (defface cook-ingredient-char-face
   '((t :inherit font-lock-string-face))
   "Face for ingredient char")


### PR DESCRIPTION
And one more!

This PR converts this:

![image](https://github.com/cooklang/cook-mode/assets/3924815/d3a8fcd7-f1bf-41c8-bb08-75aa676ffb0a)

into this:

![image](https://github.com/cooklang/cook-mode/assets/3924815/04e81426-4ba9-40c6-907f-fe4f54eddcd2)

It seems the definition of the two `course`-related faces were missing.