### PR TITLE
Bugfixes

### DIFF
--- a/cook-mode.el
+++ b/cook-mode.el
@@ -38,12 +38,12 @@
 
 (defvar cook-mode-syntax-table nil "Syntax table used while in `cook-mode'.")
 (setq cook-mode-syntax-table
-  (let ((st (make-syntax-table)))
-     (modify-syntax-entry ?\[ ". 1b" st)
-     (modify-syntax-entry ?\] ". 4b" st)
-     (modify-syntax-entry ?- ". 123b" st)
-     (modify-syntax-entry ?\n "> b" st)
-    st))
+      (let ((st (make-syntax-table)))
+        (modify-syntax-entry ?\[ "(]1nc" st)
+        (modify-syntax-entry ?\] ")[4nc" st)
+        (modify-syntax-entry ?- ". 123b" st)
+        (modify-syntax-entry ?\n "> b" st)
+        st))
 
 ;;; Regular Expressions ========================================================
 

--- a/cook-mode.el
+++ b/cook-mode.el
@@ -49,7 +49,7 @@
 
 ;; Ingredient extraction
 (defconst cook-ingredient-re
-  "\\(?1:@\\)\\(?:\\(?2:[[:alpha:]\s-]*\\){\\(?3:[^}]*\\)}\\|\\(?2:[[:alpha:]]*\\)\\)"
+  "\\(?1:@\\)\\(?:\\(?2:[[:alpha:]\n\s-]*\\){\\(?3:[^}]*\\)}\\|\\(?2:[[:alpha:]\n]*\\)\\)"
   "Regular expression for matching an ingredient.
 
 Group 1: Matches @ marker.

--- a/cook-mode.el
+++ b/cook-mode.el
@@ -49,7 +49,7 @@
 
 ;; Ingredient extraction
 (defconst cook-ingredient-re
-  "\\(?1:@\\)\\(?:\\(?2:[[:alpha:]\s-]*\\){\\(?3:[^}]*\\)}\\|\\(?2:[:alpha:]*\\)\\)"
+  "\\(?1:@\\)\\(?:\\(?2:[[:alpha:]\s-]*\\){\\(?3:[^}]*\\)}\\|\\(?2:[[:alpha:]]*\\)\\)"
   "Regular expression for matching an ingredient.
 
 Group 1: Matches @ marker.


### PR DESCRIPTION
I recently stumbled upon the cooklang-cli. I really like the idea.

Here some fixes for the emacs cook-mode:

1)The multiline block comments were fixed at least in the cases mentioned by the #3.
<img width="708" alt="grafik" src="https://github.com/user-attachments/assets/210692ce-d095-4809-bdaf-6418193cb82b" />

2) The ingredient highlighting was adjusted to 2 special cases:
2.1) single word ingredient w/o brackets (see margarine)
2.2) multi word ingredient  w/ brackets (see green onions)
<img width="727" alt="grafik" src="https://github.com/user-attachments/assets/11667859-bd05-492a-9c9f-a300dfc841e6" />

