### PR TITLE
Add cook-ts-mode: tree-sitter major mode for cooklang

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,112 @@
 # cook-mode
 
-Basic syntax highlight of cooklang on Emacs
+Emacs support for [cooklang](https://cooklang.org/) recipe files (`.cook`).
+
+The package provides two modes — both are included, and you choose which to use:
+
+| | `cook-mode` | `cook-ts-mode` |
+|---|---|---|
+| **Requires** | Any Emacs | Emacs 29.2+ |
+| **Parsing** | Regex font-lock | Tree-sitter |
+| **Extras** | — | Imenu, image overlays, YAML frontmatter |
 
 <p align="center"><img src="example.png" width="80%" title="example of syntax highlight" /></a></p>
 <p align="center">Example of syntax highlight</p>
 
-## Installation 
-### For vanilla emacs users
+---
 
-If you're running Emacs 30 or newer, you can install and load cook-mode with `use-package`:
+## Installation
 
-``` emacs-lisp
+### For vanilla Emacs users (package.el)
+
+If you're running Emacs 30 or newer, install with `use-package`:
+
+```emacs-lisp
 (use-package cook-mode
   :vc (:url "https://github.com/cooklang/cook-mode"
        :rev :newest
        :branch "master"))
 ```
 
-If you're running an older version of Emacs, download the `cook-mode.el` file and add the following to your .emacs.el or .emacs.d/init.el
-``` emacs-lisp
+### straight.el
+
+```emacs-lisp
+(straight-use-package
+ '(cook-mode :type git :host github :repo "cooklang/cook-mode"))
+```
+
+### Older Emacs
+
+Download `cook-mode.el` and add the following to your `.emacs.el` or `.emacs.d/init.el`:
+
+```emacs-lisp
 (load "/path/to/install/directory/cook-mode.el")
 ```
 
-### For doom emacs user
-Add the following to your packages.el 
-``` emacs-lisp
+### Doom Emacs
+
+Add the following to your `packages.el`:
+
+```emacs-lisp
 (package! cook-mode
-  :recipe (:host github 
-            :repo "cooklang/cook-mode"))
+  :recipe (:host github
+           :repo "cooklang/cook-mode"))
 ```
 
+---
 
+## Choosing a mode
 
+By default, loading the package activates `cook-mode` for `.cook` files. To use `cook-ts-mode` instead, first install the tree-sitter grammar (see below), then load `cook-ts-mode`:
+
+```emacs-lisp
+(require 'cook-ts-mode)
+```
+
+Once loaded, `cook-ts-mode` registers itself in two ways:
+
+- **Automatic upgrade**: if `cook-mode` is also loaded, any `.cook` file that would open in `cook-mode` is transparently redirected to `cook-ts-mode` via `major-mode-remap-alist`.
+- **Standalone**: if only `cook-ts-mode` is loaded (without `cook-mode`), it registers directly in `auto-mode-alist`.
+
+To explicitly opt out of the upgrade and keep `cook-mode` even with the grammar installed:
+
+```emacs-lisp
+(setq major-mode-remap-alist
+      (assoc-delete-all 'cook-mode major-mode-remap-alist))
+```
+
+---
+
+## cook-ts-mode: grammar installation
+
+`cook-ts-mode` requires the `cooklang` tree-sitter grammar. The easiest way is to let Emacs download and build it for you. Add this to your config:
+
+```emacs-lisp
+(add-to-list 'treesit-language-source-alist
+             '(cooklang "https://github.com/cooklang/tree-sitter-cooklang"))
+```
+
+Then install with:
+
+```
+M-x treesit-install-language-grammar RET cooklang
+```
+
+> **Note:** The key must be `cooklang` (not `cook`) — that is the grammar's internal name, which determines the dylib filename (`libtree-sitter-cooklang.dylib`).
+
+### Features
+
+- Syntax highlighting for all cooklang elements (ingredients, cookware, timers, sections, metadata, notes, comments)
+- YAML frontmatter highlighting (when the `yaml` grammar is also installed)
+- `C-c i` — display ingredient list
+- `C-c C-i` — toggle inline image display for `[- image.png -]` block comments
+- `M-;` — insert `-- ` line comment
+- `M-x imenu` — navigate to sections
+
+---
+
+## References
+
+https://www.masteringemacs.org/article/how-to-get-started-tree-sitter
+https://www.masteringemacs.org/article/lets-write-a-treesitter-major-mode
+https://batsov.com/articles/2026/02/27/building-emacs-major-modes-with-treesitter-lessons-learned/

--- a/cook-ts-mode.el
+++ b/cook-ts-mode.el
@@ -1,8 +1,9 @@
 ;;; cook-ts-mode.el --- Tree-sitter major mode for cooklang -*- lexical-binding: t -*-
 
-;; Copyright (C) 2025
+;; Copyright (C) 2026 Alexandre Avanian
 
-;; Author: aavanian
+;; Author: Alexandre Avanian <https://github.com/aavanian>
+;; Homepage: https://github.com/cooklang/cook-mode
 ;; Keywords: cooking cooklang tree-sitter
 ;; Version: 0.2.0
 ;; Package-Requires: ((emacs "29.2"))
@@ -103,6 +104,9 @@
 (defvar-local cook-ts-mode--yaml-query nil
   "Compiled query for locating frontmatter_content nodes.")
 
+(defvar-local cook-ts-mode--imenu-query nil
+  "Compiled query for locating section_name nodes.")
+
 (defun cook-ts-mode--update-yaml-ranges (&optional _beg _end _len)
   "Re-derive YAML parser ranges from the cooklang tree."
   (when (and cook-ts-mode--cooklang-parser
@@ -125,8 +129,7 @@
 Returns sections as an alist under the \\\"Sections\\\" key."
   (when cook-ts-mode--cooklang-parser
     (let* ((root (treesit-parser-root-node cook-ts-mode--cooklang-parser))
-           (query (treesit-query-compile 'cooklang '((section_name) @name)))
-           (captures (treesit-query-capture root query))
+           (captures (treesit-query-capture root cook-ts-mode--imenu-query))
            sections)
       (dolist (pair captures)
         (let* ((node (cdr pair))
@@ -171,7 +174,7 @@ Uses tree-sitter parsing, so ingredients inside comments are ignored."
 
 ;;; Ingredient display ==========================================================
 
-(defun cook-show-ingredients ()
+(defun cook-ts-mode-show-ingredients ()
   "Show ingredients from the current buffer in the echo area."
   (interactive)
   (let* ((ingredients (cook-ts-mode-ingredients))
@@ -180,7 +183,7 @@ Uses tree-sitter parsing, so ingredients inside comments are ignored."
                                  (pcase i
                                    (`(,name ,qty ,unit)
                                     (if unit
-                                        (format "%s\t%s\t%s\n" name qty unit)
+                                        (format "%s\t%s\t%s\n" name (or qty "") unit)
                                       (format "%s\t%s\n" name (or qty ""))))))
                                ingredients))))
     (if (string-empty-p table)
@@ -202,7 +205,7 @@ Uses tree-sitter parsing, so ingredients inside comments are ignored."
   (let* ((raw (treesit-node-text node t))
          ;; Strip [- and -] delimiters added by the external scanner
          (inner (replace-regexp-in-string
-                 (rx bos (? "[" "-" (* space)) (group (* nonl)) (* space) (? "-" "]") eos)
+                 (rx bos (? "[" "-" (* space)) (group (*? nonl)) (* space) (? "-" "]") eos)
                  "\\1"
                  (string-trim raw))))
     (when (cook-ts-mode--image-path-p inner)
@@ -251,6 +254,8 @@ Uses tree-sitter parsing, so ingredients inside comments are ignored."
   ;; Compile frontmatter query now that the parser exists
   (setq-local cook-ts-mode--yaml-query
               (treesit-query-compile 'cooklang '((frontmatter_content) @content)))
+  (setq-local cook-ts-mode--imenu-query
+              (treesit-query-compile 'cooklang '((section_name) @name)))
 
   (setq-local treesit-font-lock-settings cook-ts-mode--font-lock-rules)
   (setq-local treesit-font-lock-feature-list
@@ -296,19 +301,24 @@ Uses tree-sitter parsing, so ingredients inside comments are ignored."
 
   (treesit-major-mode-setup))
 
+(defvar cook-ts-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c i") #'cook-ts-mode-show-ingredients)
+    (define-key map (kbd "C-c C-i") #'cook-ts-mode-toggle-show-images)
+    map)
+  "Keymap for Cook TS major mode.")
+
 ;;;###autoload
-(define-derived-mode cook-ts-mode text-mode "Cook"
+(define-derived-mode cook-ts-mode text-mode "Cook TS"
   "Major mode for cooklang recipe files, powered by tree-sitter."
   :group 'cook-ts
 
   (unless (treesit-ready-p 'cooklang)
     (error "Tree-sitter grammar for cooklang is not available"))
 
-  (cook-ts-mode--setup)
+  (cook-ts-mode--setup))
 
-  (local-set-key (kbd "C-c i") #'cook-show-ingredients)
-  (local-set-key (kbd "C-c C-i") #'cook-ts-mode-toggle-show-images))
-
+;;;###autoload
 (when (treesit-ready-p 'cooklang)
   ;; Upgrade cook-mode → cook-ts-mode automatically when both are loaded.
   (add-to-list 'major-mode-remap-alist '(cook-mode . cook-ts-mode))

--- a/cook-ts-mode.el
+++ b/cook-ts-mode.el
@@ -1,0 +1,319 @@
+;;; cook-ts-mode.el --- Tree-sitter major mode for cooklang -*- lexical-binding: t -*-
+
+;; Copyright (C) 2025
+
+;; Author: aavanian
+;; Keywords: cooking cooklang tree-sitter
+;; Version: 0.2.0
+;; Package-Requires: ((emacs "29.2"))
+
+;;; Commentary:
+;; Tree-sitter-based major mode for cooklang recipe files.
+;; Derives from text-mode. Self-contained: does not require cook-mode.
+
+;;; Code:
+
+(require 'treesit)
+(require 'rx)
+
+;;; Font-lock rules ============================================================
+
+(defvar cook-ts-mode--font-lock-rules
+  (treesit-font-lock-rules
+
+   :language 'cooklang
+   :feature 'comment
+   `((comment) @font-lock-comment-face
+     (block_comment) @font-lock-comment-face)
+
+   :language 'cooklang
+   :feature 'keyword
+   `((metadata key: (metadata_key) @font-lock-keyword-face))
+
+   :language 'cooklang
+   :feature 'metadata
+   `((metadata ":" @font-lock-delimiter-face)
+     (metadata value: (metadata_value) @font-lock-string-face))
+
+   :language 'cooklang
+   :feature 'section
+   `((section_name) @font-lock-type-face)
+
+   :language 'cooklang
+   :feature 'ingredient
+   `("@" @font-lock-punctuation-face
+     (ingredient name: (ingredient_name) @font-lock-constant-face))
+
+   :language 'cooklang
+   :override t
+   :feature 'ingredient
+   `((ingredient name: (recipe_reference) @font-lock-string-face))
+
+   :language 'cooklang
+   :feature 'cookware
+   `("#" @font-lock-punctuation-face
+     (cookware name: (cookware_name) @font-lock-constant-face))
+
+   :language 'cooklang
+   :feature 'timer
+   `("~" @font-lock-punctuation-face
+     (timer name: (timer_name) @font-lock-constant-face))
+
+   :language 'cooklang
+   :feature 'note
+   `((recipe_note ">" @font-lock-punctuation-face)
+     (recipe_note text: (recipe_note_text) @font-lock-string-face))
+
+   :language 'cooklang
+   :feature 'number
+   `((quantity_value) @font-lock-number-face)
+
+   :language 'cooklang
+   :feature 'unit
+   `((quantity_unit) @font-lock-type-face)
+
+   :language 'cooklang
+   :feature 'operator
+   `((percent_separator) @font-lock-operator-face)
+
+   :language 'cooklang
+   :feature 'string
+   `((preparation content: (preparation_content) @font-lock-string-face))
+
+   :language 'cooklang
+   :feature 'punctuation
+   `([ "(" ")" "{" ] @font-lock-bracket-face
+     "---" @font-lock-delimiter-face)))
+
+(defvar cook-ts-mode--frontmatter-fallback-rules
+  (treesit-font-lock-rules
+   :language 'cooklang
+   :feature 'frontmatter
+   `((frontmatter_content) @font-lock-string-face))
+  "Fallback rules for frontmatter when yaml grammar is unavailable.")
+
+;;; YAML injection =============================================================
+
+(defvar-local cook-ts-mode--cooklang-parser nil
+  "Buffer-local cooklang parser.")
+
+(defvar-local cook-ts-mode--yaml-parser nil
+  "Buffer-local YAML parser, nil if yaml grammar unavailable.")
+
+(defvar-local cook-ts-mode--yaml-query nil
+  "Compiled query for locating frontmatter_content nodes.")
+
+(defun cook-ts-mode--update-yaml-ranges (&optional _beg _end _len)
+  "Re-derive YAML parser ranges from the cooklang tree."
+  (when (and cook-ts-mode--cooklang-parser
+             cook-ts-mode--yaml-parser
+             cook-ts-mode--yaml-query)
+    (when-let* ((root (treesit-parser-root-node cook-ts-mode--cooklang-parser))
+                (captures (treesit-query-capture root cook-ts-mode--yaml-query)))
+      (treesit-parser-set-included-ranges
+       cook-ts-mode--yaml-parser
+       (mapcar (lambda (pair)
+                 (let ((node (cdr pair)))
+                   (cons (treesit-node-start node)
+                         (treesit-node-end node))))
+               captures)))))
+
+;;; Imenu ======================================================================
+
+(defun cook-ts-mode--imenu-create-index ()
+  "Build imenu index for cooklang buffer.
+Returns sections as an alist under the \\\"Sections\\\" key."
+  (when cook-ts-mode--cooklang-parser
+    (let* ((root (treesit-parser-root-node cook-ts-mode--cooklang-parser))
+           (query (treesit-query-compile 'cooklang '((section_name) @name)))
+           (captures (treesit-query-capture root query))
+           sections)
+      (dolist (pair captures)
+        (let* ((node (cdr pair))
+               (raw  (treesit-node-text node t))
+               ;; Section name text includes surrounding "= =" delimiters; strip them.
+               (name (if (string-match "\\`=?[[:space:]]*\\(.*?\\)[[:space:]]*=?\\'" raw)
+                         (match-string 1 raw)
+                       raw))
+               (pos  (copy-marker (treesit-node-start node))))
+          (push (cons name pos) sections)))
+      (when sections
+        (list (cons "Sections" (nreverse sections)))))))
+
+;;; Ingredient extraction ======================================================
+
+(defun cook-ts-mode-ingredients ()
+  "Return ingredients as a list of (NAME QUANTITY UNIT) triples.
+Each element may have nil QUANTITY or UNIT when absent.
+Uses tree-sitter parsing, so ingredients inside comments are ignored."
+  (let* ((root (treesit-buffer-root-node 'cooklang))
+         (captures (treesit-query-capture root '((ingredient) @ingredient)))
+         result)
+    (dolist (pair captures)
+      (let* ((node (cdr pair))
+             (name-node (treesit-node-child-by-field-name node "name"))
+             (name-type (when name-node (treesit-node-type name-node))))
+        ;; Skip recipe references (@./path/to/Recipe) — they are not ingredients
+        (when (and name-node (string= name-type "ingredient_name"))
+          (let* ((name (treesit-node-text name-node t))
+                 (qty-node (car (treesit-filter-child
+                                 node
+                                 (lambda (n) (string= (treesit-node-type n) "quantity"))
+                                 t)))
+                 (val-node (when qty-node
+                             (treesit-node-child-by-field-name qty-node "value")))
+                 (unit-node (when qty-node
+                              (treesit-node-child-by-field-name qty-node "unit")))
+                 (qty  (when val-node  (treesit-node-text val-node t)))
+                 (unit (when unit-node (treesit-node-text unit-node t))))
+            (push (list name qty unit) result)))))
+    (nreverse result)))
+
+;;; Ingredient display ==========================================================
+
+(defun cook-show-ingredients ()
+  "Show ingredients from the current buffer in the echo area."
+  (interactive)
+  (let* ((ingredients (cook-ts-mode-ingredients))
+         (table (apply #'concat
+                       (mapcar (lambda (i)
+                                 (pcase i
+                                   (`(,name ,qty ,unit)
+                                    (if unit
+                                        (format "%s\t%s\t%s\n" name qty unit)
+                                      (format "%s\t%s\n" name (or qty ""))))))
+                               ingredients))))
+    (if (string-empty-p table)
+        (message "No ingredients found.")
+      (message "%s" table))))
+
+;;; Image overlays =============================================================
+
+(defvar-local cook-ts-mode--image-overlays nil
+  "List of overlays showing inline images.")
+
+(defun cook-ts-mode--image-path-p (text)
+  "Return non-nil if TEXT (stripped of [- -] wrapper) looks like an image path."
+  (string-match-p (rx "." (or "jpg" "jpeg" "png" "gif" "webp" "svg") eos)
+                  (string-trim text)))
+
+(defun cook-ts-mode--block-comment-image-path (node)
+  "Return the image file path from block_comment NODE, or nil."
+  (let* ((raw (treesit-node-text node t))
+         ;; Strip [- and -] delimiters added by the external scanner
+         (inner (replace-regexp-in-string
+                 (rx bos (? "[" "-" (* space)) (group (* nonl)) (* space) (? "-" "]") eos)
+                 "\\1"
+                 (string-trim raw))))
+    (when (cook-ts-mode--image-path-p inner)
+      inner)))
+
+(defun cook-ts-mode--clear-image-overlays ()
+  "Remove all image overlays from the current buffer."
+  (mapc #'delete-overlay cook-ts-mode--image-overlays)
+  (setq-local cook-ts-mode--image-overlays nil))
+
+(defun cook-ts-mode--make-image-overlays ()
+  "Create overlays for block comments whose content is an image path."
+  (cook-ts-mode--clear-image-overlays)
+  (when-let* ((root (treesit-buffer-root-node 'cooklang))
+              (captures (treesit-query-capture root '((block_comment) @bc))))
+    (dolist (pair captures)
+      (let* ((node (cdr pair))
+             (path (cook-ts-mode--block-comment-image-path node)))
+        (when path
+          (let* ((abs (expand-file-name path (file-name-directory
+                                              (or buffer-file-name default-directory))))
+                 (start (treesit-node-start node))
+                 (end   (treesit-node-end node)))
+            (when (and (file-readable-p abs)
+                       (image-type-available-p
+                        (intern (file-name-extension abs))))
+              (let* ((img (create-image abs nil nil :max-width 400))
+                     (ov  (make-overlay start end)))
+                (overlay-put ov 'display img)
+                (overlay-put ov 'cook-ts-image t)
+                (push ov cook-ts-mode--image-overlays)))))))))
+
+(defun cook-ts-mode-toggle-show-images ()
+  "Toggle inline display of images referenced in block comments."
+  (interactive)
+  (if cook-ts-mode--image-overlays
+      (cook-ts-mode--clear-image-overlays)
+    (cook-ts-mode--make-image-overlays)))
+
+;;; Major mode setup ===========================================================
+
+(defun cook-ts-mode--setup ()
+  "Set up tree-sitter for cooklang."
+  (setq-local cook-ts-mode--cooklang-parser (treesit-parser-create 'cooklang))
+
+  ;; Compile frontmatter query now that the parser exists
+  (setq-local cook-ts-mode--yaml-query
+              (treesit-query-compile 'cooklang '((frontmatter_content) @content)))
+
+  (setq-local treesit-font-lock-settings cook-ts-mode--font-lock-rules)
+  (setq-local treesit-font-lock-feature-list
+              '((comment)
+                (keyword metadata section ingredient cookware timer note)
+                (punctuation number unit operator string)))
+
+  ;; Frontmatter: inject YAML highlighting if grammar available,
+  ;; otherwise fall back to plain string face.
+  (if (treesit-language-available-p 'yaml)
+      (progn
+        (setq-local cook-ts-mode--yaml-parser (treesit-parser-create 'yaml))
+        (setq-local treesit-font-lock-settings
+                    (append treesit-font-lock-settings
+                            (treesit-font-lock-rules
+                             :language 'yaml
+                             :feature 'yaml-keyword
+                             `((block_mapping_pair key: (flow_node) @font-lock-keyword-face))
+                             :language 'yaml
+                             :feature 'yaml-string
+                             `((block_mapping_pair value: (flow_node) @font-lock-string-face)))))
+        (setq-local treesit-font-lock-feature-list
+                    '((comment)
+                      (keyword metadata section ingredient cookware timer note)
+                      (punctuation number unit operator string yaml-keyword yaml-string)))
+        (add-hook 'after-change-functions
+                  #'cook-ts-mode--update-yaml-ranges nil t)
+        (cook-ts-mode--update-yaml-ranges))
+    (setq-local treesit-font-lock-settings
+                (append treesit-font-lock-settings
+                        cook-ts-mode--frontmatter-fallback-rules))
+    (setq-local treesit-font-lock-feature-list
+                '((comment)
+                  (keyword metadata section ingredient cookware timer note)
+                  (punctuation number unit operator string frontmatter))))
+
+  ;; Imenu: sections as index entries, using explicit cooklang parser
+  (setq-local imenu-create-index-function #'cook-ts-mode--imenu-create-index)
+
+  ;; Comment syntax for M-;
+  (setq-local comment-start "-- ")
+  (setq-local comment-end "")
+
+  (treesit-major-mode-setup))
+
+;;;###autoload
+(define-derived-mode cook-ts-mode text-mode "Cook"
+  "Major mode for cooklang recipe files, powered by tree-sitter."
+  :group 'cook-ts
+
+  (unless (treesit-ready-p 'cooklang)
+    (error "Tree-sitter grammar for cooklang is not available"))
+
+  (cook-ts-mode--setup)
+
+  (local-set-key (kbd "C-c i") #'cook-show-ingredients)
+  (local-set-key (kbd "C-c C-i") #'cook-ts-mode-toggle-show-images))
+
+(when (treesit-ready-p 'cooklang)
+  ;; Upgrade cook-mode → cook-ts-mode automatically when both are loaded.
+  (add-to-list 'major-mode-remap-alist '(cook-mode . cook-ts-mode))
+  ;; Also register directly for standalone use (without cook-mode).
+  (add-to-list 'auto-mode-alist '("\\.cook\\'" . cook-ts-mode)))
+
+(provide 'cook-ts-mode)
+;;; cook-ts-mode.el ends here

--- a/example/brigadeiro.cook
+++ b/example/brigadeiro.cook
@@ -4,7 +4,7 @@
 
 [- brigadeiro.jpg -]
 
-In a #medium saucepan{} over medium heat, combine @cocoa{3*%tbsp}, @butter{1*%tbsp} and @condensed milk{1*%can}.
+In a #medium saucepan{} over medium heat, combine @cocoa{3%tbsp}, @butter{1%tbsp} and @condensed milk{1%can}.
 
 Cook, stirring, until thickened, about ~{10%minutes}.
 

--- a/test-cook-ts-mode.sh
+++ b/test-cook-ts-mode.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRATCH="$HOME/.dotfiles/emacs-profiles/scratch"
+REPO="$SCRATCH/straight/repos/cook-mode"
+GRAMMAR_DIR="$HOME/Documents/Dev/Tools/tree-sitter-cooklang"
+DYLIB_DST="$SCRATCH/tree-sitter/libtree-sitter-cooklang.dylib"
+
+# Build and install the cooklang grammar from source.
+# Emacs cannot reload dylibs, so this must run before Emacs starts.
+(cd "$GRAMMAR_DIR" && tree-sitter generate && tree-sitter build)
+cp "$GRAMMAR_DIR/cooklang.dylib" "$DYLIB_DST"
+
+SETUP="(setq treesit-extra-load-path (list \"$SCRATCH/tree-sitter\"))"
+
+case "${1:-}" in
+  --batch)
+    # Run ERT tests non-interactively.
+    emacs -Q --batch \
+      -L "$REPO" -L "$REPO/tests" \
+      --eval "$SETUP" \
+      --eval "(require 'ert)" \
+      --eval "(require 'ert-x)" \
+      --eval "(require 'cook-ts-mode-test)" \
+      --eval "(ert-run-tests-batch-and-exit)"
+    ;;
+  --grammar-test)
+    # Run tree-sitter corpus tests for the grammar itself.
+    (cd "$GRAMMAR_DIR" && tree-sitter test)
+    ;;
+  *)
+    # Interactive mode: open the example file for manual inspection.
+    emacs -Q \
+      -L "$REPO" \
+      --eval "$SETUP" \
+      --eval "(require 'cook-ts-mode) (find-file \"$REPO/example/brigadeiro.cook\")"
+    ;;
+esac

--- a/test-cook-ts-mode.sh
+++ b/test-cook-ts-mode.sh
@@ -1,17 +1,31 @@
 #!/bin/bash
 set -euo pipefail
 
-SCRATCH="$HOME/.dotfiles/emacs-profiles/scratch"
-REPO="$SCRATCH/straight/repos/cook-mode"
-GRAMMAR_DIR="$HOME/Documents/Dev/Tools/tree-sitter-cooklang"
-DYLIB_DST="$SCRATCH/tree-sitter/libtree-sitter-cooklang.dylib"
+# Required environment variables:
+#   COOKLANG_GRAMMAR_REPO  path to the tree-sitter-cooklang source repository
+#   TREESIT_LOAD_PATH      directory where Emacs loads tree-sitter grammars
+
+if [ -z "${COOKLANG_GRAMMAR_REPO:-}" ]; then
+  echo "error: COOKLANG_GRAMMAR_REPO is not set" >&2
+  echo "  Set it to the path of your tree-sitter-cooklang source repository." >&2
+  exit 1
+fi
+
+if [ -z "${TREESIT_LOAD_PATH:-}" ]; then
+  echo "error: TREESIT_LOAD_PATH is not set" >&2
+  echo "  Set it to the directory where Emacs loads tree-sitter grammars." >&2
+  exit 1
+fi
+
+REPO=$(cd "$(dirname "$0")" && pwd)
+DYLIB_DST="$TREESIT_LOAD_PATH/libtree-sitter-cooklang.dylib"
 
 # Build and install the cooklang grammar from source.
 # Emacs cannot reload dylibs, so this must run before Emacs starts.
-(cd "$GRAMMAR_DIR" && tree-sitter generate && tree-sitter build)
-cp "$GRAMMAR_DIR/cooklang.dylib" "$DYLIB_DST"
+(cd "$COOKLANG_GRAMMAR_REPO" && tree-sitter generate && tree-sitter build)
+cp "$COOKLANG_GRAMMAR_REPO/cooklang.dylib" "$DYLIB_DST"
 
-SETUP="(setq treesit-extra-load-path (list \"$SCRATCH/tree-sitter\"))"
+SETUP="(setq treesit-extra-load-path (list \"$TREESIT_LOAD_PATH\"))"
 
 case "${1:-}" in
   --batch)
@@ -26,7 +40,7 @@ case "${1:-}" in
     ;;
   --grammar-test)
     # Run tree-sitter corpus tests for the grammar itself.
-    (cd "$GRAMMAR_DIR" && tree-sitter test)
+    (cd "$COOKLANG_GRAMMAR_REPO" && tree-sitter test)
     ;;
   *)
     # Interactive mode: open the example file for manual inspection.

--- a/tests/cook-ts-mode-resources/font-face.erts
+++ b/tests/cook-ts-mode-resources/font-face.erts
@@ -1,0 +1,185 @@
+Code:
+  (lambda ()
+    (require 'cook-ts-mode)
+    (cook-ts-mode)
+    (customize-set-variable 'treesit-font-lock-level 4)
+    (let ((face (symbol-name (face-at-point))))
+      (erase-buffer)
+      (insert face)))
+Point-Char: |
+
+Name: line-comment
+No-After-Newline: t
+=-=
+-- comm|ent
+=-=
+font-lock-comment-face
+=-=-=
+
+Name: block-comment
+No-After-Newline: t
+=-=
+[- block com|ment -]
+=-=
+font-lock-comment-face
+=-=-=
+
+Name: metadata-key
+No-After-Newline: t
+=-=
+>> serv|ings: 20
+=-=
+font-lock-keyword-face
+=-=-=
+
+Name: metadata-value
+No-After-Newline: t
+=-=
+>> servings: 2|0
+=-=
+font-lock-string-face
+=-=-=
+
+Name: section
+No-After-Newline: t
+=-=
+= Ingredi|ents =
+=-=
+font-lock-type-face
+=-=-=
+
+Name: ingredient-name
+No-After-Newline: t
+=-=
+@flou|r{2%cups}
+=-=
+font-lock-constant-face
+=-=-=
+
+Name: ingredient-sigil
+No-After-Newline: t
+=-=
+|@flour{2%cups}
+=-=
+font-lock-punctuation-face
+=-=-=
+
+Name: cookware-name
+No-After-Newline: t
+=-=
+#mixing bo|wl{}
+=-=
+font-lock-constant-face
+=-=-=
+
+Name: cookware-sigil
+No-After-Newline: t
+=-=
+|#mixing bowl{}
+=-=
+font-lock-punctuation-face
+=-=-=
+
+Name: timer-name
+No-After-Newline: t
+=-=
+~res|t{30%minutes}
+=-=
+font-lock-constant-face
+=-=-=
+
+Name: timer-sigil
+No-After-Newline: t
+=-=
+|~rest{30%minutes}
+=-=
+font-lock-punctuation-face
+=-=-=
+
+Name: quantity-value
+No-After-Newline: t
+=-=
+@flour{3|0%cups}
+=-=
+font-lock-number-face
+=-=-=
+
+Name: quantity-unit
+No-After-Newline: t
+=-=
+@flour{30%cu|ps}
+=-=
+font-lock-type-face
+=-=-=
+
+Name: preparation
+No-After-Newline: t
+=-=
+@butter{1%tbsp}(mel|ted)
+=-=
+font-lock-string-face
+=-=-=
+
+Name: recipe-note-text
+No-After-Newline: t
+=-=
+> Don't burn the ro|ux!
+=-=
+font-lock-string-face
+=-=-=
+
+Name: recipe-note-sigil
+No-After-Newline: t
+=-=
+|> Don't burn the roux!
+=-=
+font-lock-punctuation-face
+=-=-=
+
+Name: percent-separator
+No-After-Newline: t
+=-=
+@flour{2|%cups}
+=-=
+font-lock-operator-face
+=-=-=
+
+Name: open-brace-bracket
+No-After-Newline: t
+=-=
+@flour|{2%cups}
+=-=
+font-lock-bracket-face
+=-=-=
+
+Name: anonymous-timer-sigil
+No-After-Newline: t
+=-=
+|~{10%minutes}
+=-=
+font-lock-punctuation-face
+=-=-=
+
+Name: horizontal-rule
+No-After-Newline: t
+=-=
+|---
+=-=
+font-lock-delimiter-face
+=-=-=
+
+Name: recipe-reference
+No-After-Newline: t
+=-=
+@./sauces/|Hollandaise
+=-=
+font-lock-string-face
+=-=-=
+
+Name: cookware-quantity-value
+No-After-Newline: t
+=-=
+#pan{|2}
+=-=
+font-lock-number-face
+=-=-=

--- a/tests/cook-ts-mode-resources/yaml-injection.erts
+++ b/tests/cook-ts-mode-resources/yaml-injection.erts
@@ -1,0 +1,29 @@
+Code:
+  (lambda ()
+    (require 'cook-ts-mode)
+    (cook-ts-mode)
+    (customize-set-variable 'treesit-font-lock-level 4)
+    (let ((face (symbol-name (face-at-point))))
+      (erase-buffer)
+      (insert face)))
+Point-Char: |
+
+Name: yaml-key
+No-After-Newline: t
+=-=
+---
+serv|ings: 4
+---
+=-=
+font-lock-keyword-face
+=-=-=
+
+Name: yaml-value
+No-After-Newline: t
+=-=
+---
+servings: |4
+---
+=-=
+font-lock-string-face
+=-=-=

--- a/tests/cook-ts-mode-test.el
+++ b/tests/cook-ts-mode-test.el
@@ -1,0 +1,121 @@
+;;; cook-ts-mode-test.el --- Tests for cook-ts-mode -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;;; Code:
+(require 'ert)
+(require 'ert-x)
+(require 'treesit)
+(require 'cook-ts-mode)
+
+;;; Font-face tests ============================================================
+
+(ert-deftest cook-ts-mode-test-font-face ()
+  (skip-unless (treesit-ready-p 'cooklang))
+  (ert-test-erts-file (ert-resource-file "font-face.erts")))
+
+(ert-deftest cook-ts-mode-test-yaml-injection ()
+  "YAML keys in frontmatter get font-lock-keyword-face."
+  (skip-unless (treesit-ready-p 'cooklang))
+  (skip-unless (treesit-language-available-p 'yaml))
+  (ert-test-erts-file (ert-resource-file "yaml-injection.erts")))
+
+;;; Ingredient extraction tests ================================================
+
+(ert-deftest cook-ts-mode-test-ingredient-extraction-basic ()
+  "Tree-sitter extraction returns correct (name qty unit) triples."
+  (skip-unless (treesit-ready-p 'cooklang))
+  (with-temp-buffer
+    (insert "Add @flour{2%cups} and @butter{1%tbsp} to the mix.\n")
+    (cook-ts-mode)
+    (should (equal (cook-ts-mode-ingredients)
+                   '(("flour" "2" "cups") ("butter" "1" "tbsp"))))))
+
+(ert-deftest cook-ts-mode-test-ingredient-extraction-no-unit ()
+  "Ingredient with quantity but no unit returns nil for unit."
+  (skip-unless (treesit-ready-p 'cooklang))
+  (with-temp-buffer
+    (insert "Add @salt{to taste}.\n")
+    (cook-ts-mode)
+    (should (equal (cook-ts-mode-ingredients)
+                   '(("salt" "to taste" nil))))))
+
+(ert-deftest cook-ts-mode-test-ingredient-extraction-no-quantity ()
+  "Ingredient with no braces returns nil for qty and unit."
+  (skip-unless (treesit-ready-p 'cooklang))
+  (with-temp-buffer
+    (insert "Season with @salt and @pepper.\n")
+    (cook-ts-mode)
+    (should (equal (cook-ts-mode-ingredients)
+                   '(("salt" nil nil) ("pepper" nil nil))))))
+
+(ert-deftest cook-ts-mode-test-ingredient-extraction-ignores-comments ()
+  "Ingredients mentioned inside comments are not extracted."
+  (skip-unless (treesit-ready-p 'cooklang))
+  (with-temp-buffer
+    ;; Block comment and line comment both contain @ingredient syntax.
+    ;; Only the real @onion ingredient should appear.
+    (insert "[- @garlic{2%cloves} -]\n")
+    (insert "-- @olive oil{2%tbsp} is optional\n")
+    (insert "Chop @onion{1}.\n")
+    (cook-ts-mode)
+    (should (equal (cook-ts-mode-ingredients)
+                   '(("onion" "1" nil))))))
+
+(ert-deftest cook-ts-mode-test-ingredient-extraction-skips-references ()
+  "Recipe references (@./path/Recipe) are not included in ingredient list."
+  (skip-unless (treesit-ready-p 'cooklang))
+  (with-temp-buffer
+    (insert "Serve with @./sauces/Hollandaise{150%g} and @butter{50%g}.\n")
+    (cook-ts-mode)
+    ;; Only the real ingredient @butter appears; recipe reference is skipped.
+    (should (equal (cook-ts-mode-ingredients)
+                   '(("butter" "50" "g"))))))
+
+;;; Mode setup tests ===========================================================
+
+(ert-deftest cook-ts-mode-test-comment-start ()
+  "comment-start is set to \"-- \" in cook-ts-mode."
+  (skip-unless (treesit-ready-p 'cooklang))
+  (with-temp-buffer
+    (cook-ts-mode)
+    (should (equal comment-start "-- "))
+    (should (equal comment-end ""))))
+
+(ert-deftest cook-ts-mode-test-imenu-sections ()
+  "Sections appear in the imenu index."
+  (skip-unless (treesit-ready-p 'cooklang))
+  (with-temp-buffer
+    (insert "= Prep =\nChop @onion{1}.\n\n= Cook =\nFry in #pan{}.\n")
+    (cook-ts-mode)
+    (let* ((index (cook-ts-mode--imenu-create-index))
+           (sections (cdr (assoc "Sections" index))))
+      (should sections)
+      (should (assoc "Prep" sections))
+      (should (assoc "Cook" sections)))))
+
+;;; Image overlay tests ========================================================
+
+(ert-deftest cook-ts-mode-test-image-overlay-no-file ()
+  "No overlay is created when the referenced image file does not exist."
+  (skip-unless (treesit-ready-p 'cooklang))
+  (with-temp-buffer
+    (insert "[- nonexistent-image-xyz.png -]\n")
+    (cook-ts-mode)
+    (cook-ts-mode--make-image-overlays)
+    (should (null cook-ts-mode--image-overlays))))
+
+(ert-deftest cook-ts-mode-test-image-path-detection ()
+  "cook-ts-mode--image-path-p recognises common image extensions."
+  (should (cook-ts-mode--image-path-p "photo.jpg"))
+  (should (cook-ts-mode--image-path-p "photo.jpeg"))
+  (should (cook-ts-mode--image-path-p "icon.png"))
+  (should (cook-ts-mode--image-path-p "animation.gif"))
+  (should (cook-ts-mode--image-path-p "icon.svg"))
+  (should-not (cook-ts-mode--image-path-p "recipe.cook"))
+  (should-not (cook-ts-mode--image-path-p "notes.txt"))
+  (should-not (cook-ts-mode--image-path-p ""))
+  (should-not (cook-ts-mode--image-path-p "just text")))
+
+(provide 'cook-ts-mode-test)
+;;; cook-ts-mode-test.el ends here

--- a/tests/cook-ts-mode-test.el
+++ b/tests/cook-ts-mode-test.el
@@ -94,7 +94,28 @@
       (should (assoc "Prep" sections))
       (should (assoc "Cook" sections)))))
 
+;;; Ingredient display tests ===================================================
+
+(ert-deftest cook-ts-mode-test-show-ingredients-nil-qty ()
+  "show-ingredients displays empty string for nil quantity, not the string \"nil\"."
+  (let (output)
+    (cl-letf (((symbol-function 'cook-ts-mode-ingredients)
+               (lambda () '(("flour" nil "cups"))))
+              ((symbol-function 'message)
+               (lambda (fmt &rest args) (setq output (apply #'format fmt args)))))
+      (cook-ts-mode-show-ingredients))
+    (should (string-match-p "flour" output))
+    (should (string-match-p "cups" output))
+    (should-not (string-match-p "nil" output))))
+
 ;;; Image overlay tests ========================================================
+
+(ert-deftest cook-ts-mode-test-block-comment-image-path-strips-delimiters ()
+  "block-comment-image-path correctly strips [- -] delimiters."
+  (cl-letf (((symbol-function 'treesit-node-text)
+             (lambda (_node _no-prop) "[- brigadeiro.jpg -]")))
+    (should (equal (cook-ts-mode--block-comment-image-path nil)
+                   "brigadeiro.jpg"))))
 
 (ert-deftest cook-ts-mode-test-image-overlay-no-file ()
   "No overlay is created when the referenced image file does not exist."


### PR DESCRIPTION
 > **Note:** This PR depends on cooklang/tree-sitter-cooklang#1 being merged first. The current grammar on `main` is outdated and does not support the node types used here.

## Summary

- Adds `cook-ts-mode`, a self-contained tree-sitter major mode for `.cook` files (requires Emacs 29.2+ with the cooklang grammar)
- When loaded alongside `cook-mode`, transparently upgrades `.cook` buffers via `major-mode-remap-alist` — no user config needed
- Does not depend on `cook-mode` and can be used standalone

## Features

- Font-lock with 3-tier rules: comments, recipe structure (metadata, sections, ingredients, cookware, timers), and detail (quantities, punctuation, YAML)
- YAML font-lock injection into frontmatter blocks (when yaml grammar is available)
- Ingredient extraction via tree-sitter queries — ignores ingredients mentioned in comments or recipe references
- `C-c i` — show ingredient list in echo area
- `C-c C-i` — toggle inline image display for `[- image.png -]` block comments
- Imenu support for section navigation
- `M-;` comment support

## Tests

11 ERT tests + font-face and YAML injection `.erts` cases. Test runner: `test-cook-ts-mode.sh` (see instructions in the script).
