### PR TITLE
add yaml metadata narrowing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 EMACS = emacs
 EMACSFLAGS = -Q -L . -L tests
-ELCS = cook-mode.elc cook-ts-mode.elc tests/cook-mode-test.elc tests/cook-ts-mode-test.elc
+ELCS = cook-mode.elc cook-ts-mode.elc cook-yaml-narrow.elc tests/cook-mode-test.elc tests/cook-ts-mode-test.elc
 
 all: ${ELCS}
 clean:
@@ -10,6 +10,8 @@ clean:
 test: all
 	${EMACS} ${EMACSFLAGS} -batch -l ert -l cook-mode-test -f ert-run-tests-batch-and-exit
 	${EMACS} ${EMACSFLAGS} -batch -l ert -l cook-ts-mode-test -f ert-run-tests-batch-and-exit
+
+cook-yaml-narrow.elc: cook-mode.elc cook-ts-mode.elc
 tests/cook-mode-test.elc: cook-mode.elc
 tests/cook-ts-mode-test.elc: cook-ts-mode.elc
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ Emacs support for [cooklang](https://cooklang.org/) recipe files (`.cook`).
 
 The package provides two modes — both are included, and you choose which to use:
 
-| | `cook-mode` | `cook-ts-mode` |
-|---|---|---|
-| **Requires** | Any Emacs | Emacs 29.2+ |
-| **Parsing** | Regex font-lock | Tree-sitter |
-| **Extras** | — | Imenu, image overlays, YAML frontmatter |
+|              | `cook-mode`     | `cook-ts-mode`                          |
+|--------------+-----------------+-----------------------------------------|
+| **Requires** | Any Emacs       | Emacs 29.2+                             |
+| **Parsing**  | Regex font-lock | Tree-sitter                             |
+| **Extras**   |                 | Imenu, image overlays, YAML frontmatter |
+
 
 <p align="center"><img src="example.png" width="80%" title="example of syntax highlight" /></a></p>
 <p align="center">Example of syntax highlight</p>
@@ -100,6 +101,7 @@ M-x treesit-install-language-grammar RET cooklang
 - YAML frontmatter highlighting (when the `yaml` grammar is also installed)
 - `C-c C-i` — display ingredient list
 - `C-c C-t` — toggle inline image display for `[- image.png -]` block comments
+- `C-c C-n` — narrow to yaml metadata
 - `M-;` — insert `-- ` line comment
 - `M-x imenu` — navigate to sections
 

--- a/cook-mode.el
+++ b/cook-mode.el
@@ -22,6 +22,8 @@
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.cook" . cook-mode))
 
+(autoload 'cook-yaml-narrow "cook-yaml-narrow" nil t)
+
 (defgroup cook '()
   "Emacs mode for cooklang."
   :group 'languages
@@ -232,6 +234,7 @@ Each element is of the form (INGREDIENT QUANTITY UNITS), where UNITS can be nil.
 
 (keymap-set cook-mode-map "C-c C-i" #'cook-show-ingredients)
 (keymap-set cook-mode-map "C-c C-t" #'cook-mode-toggle-show-images)
+(keymap-set cook-mode-map "C-c C-n" #'cook-yaml-narrow)
 
 (defun cook-mode-toggle-show-images ()
   "Toggle whether to show images from comments."

--- a/cook-ts-mode.el
+++ b/cook-ts-mode.el
@@ -17,6 +17,8 @@
 (require 'treesit)
 (require 'rx)
 
+(autoload 'cook-yaml-narrow "cook-yaml-narrow" nil t)
+
 ;;; Font-lock rules ============================================================
 
 (defvar cook-ts-mode--font-lock-rules
@@ -305,6 +307,7 @@ Uses tree-sitter parsing, so ingredients inside comments are ignored."
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-i") #'cook-ts-mode-show-ingredients)
     (define-key map (kbd "C-c C-t") #'cook-ts-mode-toggle-show-images)
+    (define-key map (kbd "C-c C-n") #'cook-yaml-narrow)
     map)
   "Keymap for Cook TS major mode.")
 

--- a/cook-yaml-narrow.el
+++ b/cook-yaml-narrow.el
@@ -1,0 +1,86 @@
+;;; cook-yaml-narrow.el --- yaml narrowing within cook-mode metadata -*- lexical-binding: t; -*-
+
+;; Author: Andrew Chi <chifamicom@outlook.com>
+;; Created: 10 May 2026
+;; Version: 0.0.1
+;; Keywords: languages, convenience
+;;
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+;;
+;; This would enable editing yaml without having to throw in an entire yaml
+;; parser.  The end user may also have specialized key bindings in a yaml
+;; major-mode that would not appear in `cook-mode', giving them a better
+;; experience editing the buffer.
+;;
+;; This module works on `cook-mode' and `cook-ts-mode'.
+
+;;; Code:
+
+(defgroup cook-yaml-narrow '()
+  "Yaml narrowing for `cook-mode' metadata."
+  :group 'cook
+  :prefix "cook-yaml-narrow-")
+
+(defcustom cook-yaml-narrow-default-yaml-major-mode (cond
+                                                     ;; yaml-mode is not provided with Emacs
+                                                     ((fboundp 'yaml-mode)
+                                                      'yaml-mode)
+                                                     ;; people may be trying to avoid tree-sitter but this is a good default
+                                                     ((treesit-language-available-p 'yaml)
+                                                      #'yaml-ts-mode)
+                                                     (t
+                                                      #'fundamental-mode))
+  "The major-mode for yaml when narrowed without tree-sitter."
+  :group 'cook-yaml-narrow
+  :type 'function)
+
+(defcustom cook-yaml-narrow-inhibit-message-p nil
+  "Whether to remove the message reminding you how to widen the buffer."
+  :group 'cook-yaml-narrow
+  :type 'boolean)
+
+(defun cook-yaml-narrow-pick-major-mode ()
+  "Pick a major mode to handle yaml with.
+
+The choice is based on the current major mode."
+  (if (derived-mode-p 'cook-mode)
+      (funcall cook-yaml-narrow-default-yaml-major-mode)
+    (yaml-ts-mode)))
+
+(defun cook-yaml-narrow-widen ()
+  "`widen' the current buffer and go back to `cook-mode'."
+  (interactive)
+  (widen)
+  (if (derived-mode-p 'yaml-ts-mode)
+      (progn
+        (eval-and-compile (require 'cook-ts-mode))
+        (cook-ts-mode))
+    (eval-and-compile (require 'cook-mode))
+    (cook-mode))
+
+  (keymap-local-unset "<remap> <widen>"))
+
+(defun cook-yaml-narrow ()
+  "Narrow to only the yaml metadata section."
+  (interactive)
+  (let ((start (save-excursion
+                 (re-search-backward "^---$")
+                 (forward-line)
+                 (point)))
+        (end (save-excursion
+               (re-search-forward "^---$")
+               (beginning-of-line 0)
+               (point))))
+    (narrow-to-region start end)
+    (cook-yaml-narrow-pick-major-mode)
+
+    (keymap-local-set "<remap> <widen>" #'cook-yaml-narrow-widen)
+
+    (unless cook-yaml-narrow-inhibit-message-p
+      (message "Widen the buffer with `C-x n w'."))))
+
+(provide 'cook-yaml-narrow)
+
+;;; cook-yaml-narrow.el ends here


### PR DESCRIPTION
From in the commentary section:

```elisp
;; This would enable editing yaml without having to throw in an entire yaml
;; parser.  The end user may also have specialized key bindings in a yaml
;; major-mode that would not appear in `cook-mode', giving them a better
;; experience editing the buffer.
;;
;; This module works on `cook-mode' and `cook-ts-mode'.
```

I have not tested the code on the tree-sitter mode yet but it would
most likely work.

- **add narrowing to yaml metadata**
